### PR TITLE
Fix CI matrix build

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -5,13 +5,10 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     name: Build and test
-
     strategy:
       matrix:
         go-version: [1.14]
-
       fail-fast: true
 
     steps:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: CI  Backend
+    name: Build and test
 
     strategy:
       matrix:
@@ -15,10 +15,10 @@ jobs:
       fail-fast: true
 
     steps:
-      - name: Set up Go ${{ matrix.node-version }}
+      - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ matrix.node-version }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -30,7 +30,8 @@ jobs:
           echo $result
           [ -n "$result" ] && exit 1 || exit 0
 
-      - uses: actions/cache@v1
+      - name: cache dependencies
+        uses: actions/cache@v1
         id: go-mod-cache
         with:
           path: ~/go/pkg/mod
@@ -45,10 +46,10 @@ jobs:
         run: |
           make build
 
-      - name: Test and Cover
+      - name: Test and adn coverage report
         run: go test -v -race -count=1 -covermode=atomic -coverprofile=coverage.out ./...
 
-      - name: Upload Code Coverage
+      - name: Upload code coverage report
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The matrix build was actually no working, the matrix loop was pointing to a nnon existing node version. There for the system default version of Go was used. Create a small fix and added some name descriptions to the ci workflow.

<img width="247" alt="go-matrix" src="https://user-images.githubusercontent.com/11609620/85616148-97032180-b65d-11ea-9ddc-57a34c62a7d0.png">
