### PR TITLE
Add github repository description, resolves #20

### DIFF
--- a/lib/github/github.go
+++ b/lib/github/github.go
@@ -65,15 +65,16 @@ type RestRepo struct {
 }
 
 type Repository struct {
-	Name       string     `json:"name,omitempty"`
-	ID         string     `json:"id,omitempty"`
-	URL        string     `json:"url,omitempty"`
-	SSHURL     string     `json:"ssh_url,omitempty"`
-	Owner      string     `json:"owner,omitempty"`
-	Visibility Visibility `json:"visibility"`
-	CreatedAt  time.Time  `json:"created_at,omitempty"`
-	UpdatedAt  time.Time  `json:"updated_at,omitempty"`
-	PushedAt   time.Time  `json:"pushed_at,omitempty"`
+	ID          string     `json:"id,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Description string     `json:"description,omitempty"`
+	URL         string     `json:"url,omitempty"`
+	SSHURL      string     `json:"ssh_url,omitempty"`
+	Owner       string     `json:"owner,omitempty"`
+	Visibility  Visibility `json:"visibility"`
+	CreatedAt   time.Time  `json:"created_at,omitempty"`
+	UpdatedAt   time.Time  `json:"updated_at,omitempty"`
+	PushedAt    time.Time  `json:"pushed_at,omitempty"`
 }
 
 func (c *Client) FetchOrganziationRepositories(ctx context.Context, owner string) ([]Repository, error) {
@@ -129,14 +130,15 @@ func Map(repositories []graphql.Repository, privateRepositories []RestRepo) ([]R
 	repos := make([]Repository, len(repositories))
 	for i, repo := range repositories {
 		repos[i] = Repository{
-			Name:      repo.Name,
-			ID:        repo.ID,
-			URL:       repo.URL,
-			SSHURL:    repo.SSHURL,
-			Owner:     repo.Owner.Login,
-			CreatedAt: repo.CreatedAt,
-			UpdatedAt: repo.UpdatedAt,
-			PushedAt:  repo.PushedAt,
+			ID:          repo.ID,
+			Name:        repo.Name,
+			Description: strings.TrimSpace(repo.Description),
+			URL:         repo.URL,
+			SSHURL:      repo.SSHURL,
+			Owner:       repo.Owner.Login,
+			CreatedAt:   repo.CreatedAt,
+			UpdatedAt:   repo.UpdatedAt,
+			PushedAt:    repo.PushedAt,
 		}
 
 		if repo.IsPrivate {

--- a/lib/github/graphql/graphql.go
+++ b/lib/github/graphql/graphql.go
@@ -16,15 +16,16 @@ type Owner struct {
 }
 
 type Repository struct {
-	Name      string    `json:"name,omitempty"`
-	ID        string    `json:"id,omitempty"`
-	URL       string    `json:"url,omitempty"`
-	SSHURL    string    `json:"ssh_url,omitempty"`
-	Owner     Owner     `json:"owner,omitempty"`
-	IsPrivate bool      `json:"is_private,omitempty"`
-	CreatedAt time.Time `json:"created_at,omitempty"`
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
-	PushedAt  time.Time `json:"pushed_at,omitempty"`
+	ID          string    `json:"id,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Description string    `json:"description,omitempty"`
+	URL         string    `json:"url,omitempty"`
+	SSHURL      string    `json:"ssh_url,omitempty"`
+	Owner       Owner     `json:"owner,omitempty"`
+	IsPrivate   bool      `json:"is_private,omitempty"`
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+	PushedAt    time.Time `json:"pushed_at,omitempty"`
 }
 
 type Repositories struct {


### PR DESCRIPTION
Adds repository description to results.

Can be printed in `json` or `templated` formats.
