### PR TITLE
Feature/contributors owners

### DIFF
--- a/lib/github/graphql/graphql.go
+++ b/lib/github/graphql/graphql.go
@@ -27,6 +27,7 @@ type Repository struct {
 	UpdatedAt        time.Time        `json:"updated_at,omitempty"`
 	PushedAt         time.Time        `json:"pushed_at,omitempty"`
 	RepositoryTopics RepositoryTopics `graphql:"repositoryTopics(first: 25)" json:"repository_topics,omitempty"`
+	Collaborators    Collaborators    `graphql:"collaborators(first: 15)" json:"collaborators,omitempty"`
 }
 
 type RepositoryTopics struct {
@@ -46,6 +47,18 @@ type Repositories struct {
 	TotalCount int          `json:"total_count,omitempty"`
 	PageInfo   PageInfo     `json:"page_info,omitempty"`
 	Nodes      []Repository `json:"nodes,omitempty"`
+}
+
+type Collaborators struct {
+	TotalCount int            `json:"total_count,omitempty"`
+	PageInfo   PageInfo       `json:"page_info,omitempty"`
+	Nodes      []Collaborator `json:"nodes,omitempty"`
+}
+
+type Collaborator struct {
+	Name      string `json:"name,omitempty"`
+	Login     string `json:"login,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
 }
 
 type Organization struct {

--- a/lib/github/graphql/search.go
+++ b/lib/github/graphql/search.go
@@ -1,0 +1,15 @@
+package graphql
+
+type RepositorySearch struct {
+	RepositoryCount int
+	PageInfo        PageInfo
+	Edges           []Edge
+}
+
+type Edge struct {
+	Node Node
+}
+
+type Node struct {
+	Repository Repository `graphql:"... on Repository"`
+}

--- a/lib/github/repositories.go
+++ b/lib/github/repositories.go
@@ -102,6 +102,9 @@ func (c *Client) FetchOrganziationRepositories(ctx context.Context, owner string
 		Repositories graphql.RepositorySearch `graphql:"search(query: $query, type: REPOSITORY, first:100, after: $repoCursor)""`
 	}
 
+	// archived repositories are filtered as they give error when fetching collaborators
+	// this bug is known with Github.
+	// Also see https://github.com/shurcooL/githubv4/issues/72, on proposal for better error handling
 	variables := map[string]interface{}{
 		"query":      githubv4.String(fmt.Sprintf("org:%s archived:false", owner)),
 		"repoCursor": (*githubv4.String)(nil),

--- a/lib/github/repositories.go
+++ b/lib/github/repositories.go
@@ -191,8 +191,8 @@ func mapTopics(topics graphql.RepositoryTopics) []Topic {
 
 func mapCollaborators(collaborators graphql.Collaborators) []Collaborator {
 	ghCollaborators := make([]Collaborator, len(collaborators.Nodes))
-	for i, collaborator := range collaborators.Nodes {
-		ghCollaborators[i] = Collaborator{&collaborator}
+	for i := range collaborators.Nodes {
+		ghCollaborators[i] = Collaborator{&collaborators.Nodes[i]}
 	}
 	return ghCollaborators
 }

--- a/lib/github/repositories.go
+++ b/lib/github/repositories.go
@@ -74,17 +74,22 @@ type RestRepo struct {
 }
 
 type Repository struct {
-	ID          string     `json:"id,omitempty"`
-	Name        string     `json:"name,omitempty"`
-	Description string     `json:"description,omitempty"`
-	URL         string     `json:"url,omitempty"`
-	SSHURL      string     `json:"ssh_url,omitempty"`
-	Owner       string     `json:"owner,omitempty"`
-	Visibility  Visibility `json:"visibility"`
-	CreatedAt   time.Time  `json:"created_at,omitempty"`
-	UpdatedAt   time.Time  `json:"updated_at,omitempty"`
-	PushedAt    time.Time  `json:"pushed_at,omitempty"`
-	Topics      []Topic    `json:"topics,omitempty"`
+	ID            string         `json:"id,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	URL           string         `json:"url,omitempty"`
+	SSHURL        string         `json:"ssh_url,omitempty"`
+	Owner         string         `json:"owner,omitempty"`
+	Visibility    Visibility     `json:"visibility"`
+	CreatedAt     time.Time      `json:"created_at,omitempty"`
+	UpdatedAt     time.Time      `json:"updated_at,omitempty"`
+	PushedAt      time.Time      `json:"pushed_at,omitempty"`
+	Topics        []Topic        `json:"topics,omitempty"`
+	Collaborators []Collaborator `json:"collaborators,omitempty"`
+}
+
+type Collaborator struct {
+	*graphql.Collaborator
 }
 
 type Topic struct {
@@ -138,16 +143,17 @@ func Map(repositories []graphql.Repository, privateRepositories []*github.Reposi
 	repos := make([]Repository, len(repositories))
 	for i, repo := range repositories {
 		repos[i] = Repository{
-			ID:          repo.ID,
-			Name:        repo.Name,
-			Description: strings.TrimSpace(repo.Description),
-			URL:         repo.URL,
-			SSHURL:      repo.SSHURL,
-			Owner:       repo.Owner.Login,
-			CreatedAt:   repo.CreatedAt,
-			UpdatedAt:   repo.UpdatedAt,
-			PushedAt:    repo.PushedAt,
-			Topics:      mapTopics(repo.RepositoryTopics),
+			ID:            repo.ID,
+			Name:          repo.Name,
+			Description:   strings.TrimSpace(repo.Description),
+			URL:           repo.URL,
+			SSHURL:        repo.SSHURL,
+			Owner:         repo.Owner.Login,
+			CreatedAt:     repo.CreatedAt,
+			UpdatedAt:     repo.UpdatedAt,
+			PushedAt:      repo.PushedAt,
+			Topics:        mapTopics(repo.RepositoryTopics),
+			Collaborators: mapCollaborators(repo.Collaborators),
 		}
 
 		if repo.IsPrivate {
@@ -178,4 +184,12 @@ func mapTopics(topics graphql.RepositoryTopics) []Topic {
 		ghTopics[i] = Topic{Name: topic.Topic.Name, URL: fmt.Sprintf("https://github.com%s", topic.ResourcePath)}
 	}
 	return ghTopics
+}
+
+func mapCollaborators(collaborators graphql.Collaborators) []Collaborator {
+	ghCollaborators := make([]Collaborator, len(collaborators.Nodes))
+	for i, collaborator := range collaborators.Nodes {
+		ghCollaborators[i] = Collaborator{&collaborator}
+	}
+	return ghCollaborators
 }

--- a/lib/github/repositories_test.go
+++ b/lib/github/repositories_test.go
@@ -65,11 +65,16 @@ func TestMap(t *testing.T) {
 			graphql.RepositoryTopic{Topic: graphql.Topic{Name: "graphql"}, ResourcePath: "/topics/graphql"},
 		},
 	}
+	collaborators := graphql.Collaborators{
+		Nodes: []graphql.Collaborator{
+			graphql.Collaborator{Name: "Marco Franssen", Login: "marcofranssen", AvatarURL: "https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4"},
+		},
+	}
 	graphqlRepositories := []graphql.Repository{
 		graphql.Repository{Owner: owner, Name: "private-repo", Description: "I am private ", IsPrivate: true},
 		graphql.Repository{Owner: owner, Name: "internal-repo", Description: "Superb inner-source stuff", IsPrivate: true},
 		graphql.Repository{Owner: owner, Name: "opensource", Description: "I'm shared with the world", RepositoryTopics: topics},
-		graphql.Repository{Owner: owner, Name: "secret-repo", Description: " ** secrets ** ", IsPrivate: true},
+		graphql.Repository{Owner: owner, Name: "secret-repo", Description: " ** secrets ** ", IsPrivate: true, Collaborators: collaborators},
 	}
 
 	privateRepos := []*gh.Repository{
@@ -103,6 +108,10 @@ func TestMap(t *testing.T) {
 	assert.Equal("https://github.com/topics/golang", ghRepos[2].Topics[1].URL)
 	assert.Equal("graphql", ghRepos[2].Topics[2].Name)
 	assert.Equal("https://github.com/topics/graphql", ghRepos[2].Topics[2].URL)
+
+	assert.Equal("Marco Franssen", ghRepos[3].Collaborators[0].Name)
+	assert.Equal("marcofranssen", ghRepos[3].Collaborators[0].Login)
+	assert.Equal("https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4", ghRepos[3].Collaborators[0].AvatarURL)
 }
 
 func stringPointer(s string) *string {

--- a/lib/github/repositories_test.go
+++ b/lib/github/repositories_test.go
@@ -68,6 +68,7 @@ func TestMap(t *testing.T) {
 	collaborators := graphql.Collaborators{
 		Nodes: []graphql.Collaborator{
 			graphql.Collaborator{Name: "Marco Franssen", Login: "marcofranssen", AvatarURL: "https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4"},
+			graphql.Collaborator{Name: "John Doe", Login: "johndoe", AvatarURL: "https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4"},
 		},
 	}
 	graphqlRepositories := []graphql.Repository{
@@ -109,9 +110,14 @@ func TestMap(t *testing.T) {
 	assert.Equal("graphql", ghRepos[2].Topics[2].Name)
 	assert.Equal("https://github.com/topics/graphql", ghRepos[2].Topics[2].URL)
 
+	assert.Len(ghRepos[3].Collaborators, 2)
 	assert.Equal("Marco Franssen", ghRepos[3].Collaborators[0].Name)
 	assert.Equal("marcofranssen", ghRepos[3].Collaborators[0].Login)
 	assert.Equal("https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4", ghRepos[3].Collaborators[0].AvatarURL)
+
+	assert.Equal("John Doe", ghRepos[3].Collaborators[1].Name)
+	assert.Equal("johndoe", ghRepos[3].Collaborators[1].Login)
+	assert.Equal("https://avatars3.githubusercontent.com/u/694733?u=6aeb327c48cb88ae31eb88e680b96228f53cae51&v=4", ghRepos[3].Collaborators[1].AvatarURL)
 }
 
 func stringPointer(s string) *string {


### PR DESCRIPTION
This adds repository collaborators. However for some reason we are getting following error.

Somehow it fails with following message.

```bash
$ bin/tabia github repositories -O philips-labs -F json
2020/07/24 15:15:19 Must have push access to view repository collaborators.
```

This very same query invoked using the same token from graphql playground succeeds.

Need to have a closer look at the query.

```graphql
# Write your query or mutation here
query organizationRepositories($owner: String!) {
        organization(login:$owner) {
          repositories(first: 100) {
            totalCount
            nodes {
              owner {
                login
              }
              collaborators(first: 15) {
                nodes {
                  name
                  login
                  avatarUrl
                }
              }
              repositoryTopics(first: 25) {
                nodes {
                  topic {
                    name
                  }
                }
              }
              name
              id
              url
              description
              isPrivate
            }
          }
        }
      }
```