### PR TITLE
add a verbose option to bitbucket cli

### DIFF
--- a/lib/bitbucket/bitbucket.go
+++ b/lib/bitbucket/bitbucket.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 
 	"golang.org/x/net/proxy"
+
+	"github.com/philips-labs/tabia/lib/transport"
 )
 
 type PagedResponse struct {
@@ -46,11 +48,18 @@ type TokenAuth struct {
 	Token string
 }
 
-func NewClientWithBasicAuth(endpoint, username, password string) *Client {
+func NewClientWithBasicAuth(endpoint, username, password string, writer io.Writer) *Client {
+	httpClient := new(http.Client)
+	if writer != nil {
+		httpClient.Transport = transport.TeeRoundTripper{
+			RoundTripper: new(http.Transport),
+			Writer:       writer,
+		}
+	}
 	c := &Client{
 		baseEndpoint: endpoint,
 		Auth:         BasicAuth{Username: username, Password: password},
-		HttpClient:   new(http.Client),
+		HttpClient:   httpClient,
 	}
 
 	c.Projects = Projects{c}
@@ -58,11 +67,18 @@ func NewClientWithBasicAuth(endpoint, username, password string) *Client {
 	return c
 }
 
-func NewClientWithTokenAuth(endpoint, token string) *Client {
+func NewClientWithTokenAuth(endpoint, token string, writer io.Writer) *Client {
+	httpClient := new(http.Client)
+	if writer != nil {
+		httpClient.Transport = transport.TeeRoundTripper{
+			RoundTripper: new(http.Transport),
+			Writer:       writer,
+		}
+	}
 	c := &Client{
 		baseEndpoint: endpoint,
 		Auth:         TokenAuth{Token: token},
-		HttpClient:   new(http.Client),
+		HttpClient:   httpClient,
 	}
 	c.Projects = Projects{c}
 	c.Repositories = Repositories{c}

--- a/lib/bitbucket/bitbucket_test.go
+++ b/lib/bitbucket/bitbucket_test.go
@@ -18,7 +18,7 @@ func bitbucketTestClient(handler http.Handler) (*bitbucket.Client, string, func(
 	baseUrl := s.Listener.Addr().String()
 	apiUrl := "http://" + baseUrl + "/rest/api/1.0"
 	token := os.Getenv("TABIA_BITBUCKET_TOKEN")
-	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token)
+	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token, nil)
 	bb.HttpClient.Transport = &http.Transport{
 		DialContext: func(_ context.Context, network, _ string) (net.Conn, error) {
 			return net.Dial(network, baseUrl)
@@ -35,7 +35,7 @@ func TestClientWithTokenAuth(t *testing.T) {
 	baseUrl := s.Listener.Addr().String()
 	apiUrl := "http://" + baseUrl + "/rest/api/1.0"
 	token := "asd12bjkhu23uy12iu3hh"
-	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token)
+	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token, nil)
 
 	assert.Equal(bitbucket.TokenAuth{Token: token}, bb.Auth)
 }
@@ -48,7 +48,7 @@ func TestClientWithBasicAuth(t *testing.T) {
 	apiUrl := "http://" + baseUrl + "/rest/api/1.0"
 	user := "johndoe"
 	pass := "S3cr3t!"
-	bb := bitbucket.NewClientWithBasicAuth(apiUrl, user, pass)
+	bb := bitbucket.NewClientWithBasicAuth(apiUrl, user, pass, nil)
 
 	assert.Equal(bitbucket.BasicAuth{Username: user, Password: pass}, bb.Auth)
 }

--- a/lib/bitbucket/bitbucket_test.go
+++ b/lib/bitbucket/bitbucket_test.go
@@ -2,10 +2,12 @@ package bitbucket_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,24 +33,43 @@ func bitbucketTestClient(handler http.Handler) (*bitbucket.Client, string, func(
 func TestClientWithTokenAuth(t *testing.T) {
 	assert := assert.New(t)
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{ "name": "My repo" }`)
+	}))
 	baseUrl := s.Listener.Addr().String()
 	apiUrl := "http://" + baseUrl + "/rest/api/1.0"
 	token := "asd12bjkhu23uy12iu3hh"
-	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token, nil)
+	project := "philips-internal"
+
+	var writer strings.Builder
+	bb := bitbucket.NewClientWithTokenAuth(apiUrl, token, &writer)
 
 	assert.Equal(bitbucket.TokenAuth{Token: token}, bb.Auth)
+
+	_, err := bb.Repositories.List(project)
+	assert.NoError(err)
+	assert.NotEmpty(writer)
+	assert.Equal(fmt.Sprintf("GET: %s/projects/%s/repos?limit=100 ", apiUrl, project), writer.String())
 }
 
 func TestClientWithBasicAuth(t *testing.T) {
 	assert := assert.New(t)
 
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{ "name": "My repo" }`)
+	}))
 	baseUrl := s.Listener.Addr().String()
 	apiUrl := "http://" + baseUrl + "/rest/api/1.0"
 	user := "johndoe"
 	pass := "S3cr3t!"
-	bb := bitbucket.NewClientWithBasicAuth(apiUrl, user, pass, nil)
+	project := "philips-internal"
+	var writer strings.Builder
+	bb := bitbucket.NewClientWithBasicAuth(apiUrl, user, pass, &writer)
 
 	assert.Equal(bitbucket.BasicAuth{Username: user, Password: pass}, bb.Auth)
+
+	_, err := bb.Repositories.List(project)
+	assert.NoError(err)
+	assert.NotEmpty(writer)
+	assert.Equal(fmt.Sprintf("GET: %s/projects/%s/repos?limit=100 ", apiUrl, project), writer.String())
 }


### PR DESCRIPTION
### Issue Endorsed by Maintainers
https://github.com/philips-labs/tabia/issues/37

I would like to start contributing to open source projects.
This issue is not with `help-wanted` or `triaged`, but `good first issue`, so I challenged contribute.

### Description of the Change
I added a `--verbose` option to bitbucket command.
I referenced the implementation of github cli of #36.

### Alternate Designs
nothing.

### Possible Drawbacks
may be nothing.

### Verification Process
I executed the bitbucket cli as shown blow.
`bin/tabia bitbucket --verbose repositories -P <project_name> -F json`

### Release Notes
The bitcuket cli now allows you to log requests with verbose flag.