### PR TITLE
Add github stars, watchers and fork counts to repositories

### DIFF
--- a/lib/github/graphql/graphql.go
+++ b/lib/github/graphql/graphql.go
@@ -16,19 +16,22 @@ type Owner struct {
 }
 
 type Repository struct {
-	ID               string           `json:"id,omitempty"`
-	Name             string           `json:"name,omitempty"`
-	Description      string           `json:"description,omitempty"`
-	URL              string           `json:"url,omitempty"`
-	SSHURL           string           `json:"ssh_url,omitempty"`
-	Owner            Owner            `json:"owner,omitempty"`
-	IsPrivate        bool             `json:"is_private,omitempty"`
-	CreatedAt        time.Time        `json:"created_at,omitempty"`
-	UpdatedAt        time.Time        `json:"updated_at,omitempty"`
-	PushedAt         time.Time        `json:"pushed_at,omitempty"`
-	RepositoryTopics RepositoryTopics `graphql:"repositoryTopics(first: 25)" json:"repository_topics,omitempty"`
-	Collaborators    Collaborators    `graphql:"collaborators(first: 15, affiliation: DIRECT)" json:"collaborators,omitempty"`
-	Languages        Languages        `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})" json:"languages,omitempty"`
+	ID               string               `json:"id,omitempty"`
+	Name             string               `json:"name,omitempty"`
+	Description      string               `json:"description,omitempty"`
+	URL              string               `json:"url,omitempty"`
+	SSHURL           string               `json:"ssh_url,omitempty"`
+	Owner            Owner                `json:"owner,omitempty"`
+	IsPrivate        bool                 `json:"is_private,omitempty"`
+	CreatedAt        time.Time            `json:"created_at,omitempty"`
+	UpdatedAt        time.Time            `json:"updated_at,omitempty"`
+	PushedAt         time.Time            `json:"pushed_at,omitempty"`
+	RepositoryTopics RepositoryTopics     `graphql:"repositoryTopics(first: 25)" json:"repository_topics,omitempty"`
+	Collaborators    Collaborators        `graphql:"collaborators(first: 15, affiliation: DIRECT)" json:"collaborators,omitempty"`
+	Languages        Languages            `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})" json:"languages,omitempty"`
+	ForkCount        int                  `json:"fork_count,omitempty"`
+	Stargazers       StargazersConnection `graphql:"stargazers(first: 0)" json:"stargazers,omitempty"`
+	Watchers         UserConnection       `graphql:"watchers(first: 0)" json:"watchers,omitempty"`
 }
 
 type Languages struct {
@@ -74,6 +77,14 @@ type Collaborator struct {
 	Name      string `json:"name,omitempty"`
 	Login     string `json:"login,omitempty"`
 	AvatarURL string `json:"avatar_url,omitempty"`
+}
+
+type StargazersConnection struct {
+	TotalCount int `json:"total_count,omitempty"`
+}
+
+type UserConnection struct {
+	TotalCount int `json:"total_count,omitempty"`
 }
 
 type Organization struct {

--- a/lib/github/repositories.go
+++ b/lib/github/repositories.go
@@ -48,19 +48,22 @@ type RestRepo struct {
 }
 
 type Repository struct {
-	ID            string         `json:"id,omitempty"`
-	Name          string         `json:"name,omitempty"`
-	Description   string         `json:"description,omitempty"`
-	URL           string         `json:"url,omitempty"`
-	SSHURL        string         `json:"ssh_url,omitempty"`
-	Owner         string         `json:"owner,omitempty"`
-	Visibility    Visibility     `json:"visibility"`
-	CreatedAt     time.Time      `json:"created_at,omitempty"`
-	UpdatedAt     time.Time      `json:"updated_at,omitempty"`
-	PushedAt      time.Time      `json:"pushed_at,omitempty"`
-	Topics        []Topic        `json:"topics,omitempty"`
-	Languages     []Language     `json:"languages,omitempty"`
-	Collaborators []Collaborator `json:"collaborators,omitempty"`
+	ID             string         `json:"id,omitempty"`
+	Name           string         `json:"name,omitempty"`
+	Description    string         `json:"description,omitempty"`
+	URL            string         `json:"url,omitempty"`
+	SSHURL         string         `json:"ssh_url,omitempty"`
+	Owner          string         `json:"owner,omitempty"`
+	Visibility     Visibility     `json:"visibility"`
+	CreatedAt      time.Time      `json:"created_at,omitempty"`
+	UpdatedAt      time.Time      `json:"updated_at,omitempty"`
+	PushedAt       time.Time      `json:"pushed_at,omitempty"`
+	ForkCount      int            `json:"fork_count,omitempty"`
+	StargazerCount int            `json:"stargazer_count,omitempty"`
+	WatcherCount   int            `json:"watcher_count,omitempty"`
+	Topics         []Topic        `json:"topics,omitempty"`
+	Languages      []Language     `json:"languages,omitempty"`
+	Collaborators  []Collaborator `json:"collaborators,omitempty"`
 }
 
 type Collaborator struct {
@@ -140,18 +143,21 @@ func Map(repositories []graphql.Repository, privateRepositories []*github.Reposi
 	repos := make([]Repository, len(repositories))
 	for i, repo := range repositories {
 		repos[i] = Repository{
-			ID:            repo.ID,
-			Name:          repo.Name,
-			Description:   strings.TrimSpace(repo.Description),
-			URL:           repo.URL,
-			SSHURL:        repo.SSHURL,
-			Owner:         repo.Owner.Login,
-			CreatedAt:     repo.CreatedAt,
-			UpdatedAt:     repo.UpdatedAt,
-			PushedAt:      repo.PushedAt,
-			Topics:        mapTopics(repo.RepositoryTopics),
-			Languages:     mapLanguages(repo.Languages),
-			Collaborators: mapCollaborators(repo.Collaborators),
+			ID:             repo.ID,
+			Name:           repo.Name,
+			Description:    strings.TrimSpace(repo.Description),
+			URL:            repo.URL,
+			SSHURL:         repo.SSHURL,
+			Owner:          repo.Owner.Login,
+			CreatedAt:      repo.CreatedAt,
+			UpdatedAt:      repo.UpdatedAt,
+			PushedAt:       repo.PushedAt,
+			ForkCount:      repo.ForkCount,
+			StargazerCount: repo.Stargazers.TotalCount,
+			WatcherCount:   repo.Watchers.TotalCount,
+			Topics:         mapTopics(repo.RepositoryTopics),
+			Languages:      mapLanguages(repo.Languages),
+			Collaborators:  mapCollaborators(repo.Collaborators),
 		}
 
 		if repo.IsPrivate {


### PR DESCRIPTION
This allows usage in github-organization-metrics.

```bash
bin/tabia github repositories -O philips-internal \
  -O philips-software \
  -O philips-labs \
  -f "$repo_filter" -F templated -T templates/repositories.csv.tmpl \
  > output/`date +%F`-repositories.csv
```

The template would look like this.

```
Organization,Visibility,Repository,Url,Stars,Watchers,Forks
{{- range . }}
{{ .Owner }},{{ .Name }},{{ .Visibility }},{{ .URL }},{{ .StargazerCount }},{{ .WatcherCount }},{{ .ForkCount -}}
{{ end -}}

```

Will make another PR to utilize this feature in github-organization-metrics for that once this PR is merged and tabia release is created.
